### PR TITLE
Use custom `softmax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  - Add option to save results to a `HDF5` file when `.h5` extension is used in `predict_output` ([#41](https://github.com/tzuhanchang/HyPER/pull/41))
 
 ### Changed
+ - Customize `softmax` function ([#36](https://github.com/tzuhanchang/HyPER/pull/36))
 
 ### Deprecated
 

--- a/HyPER/models/hyperedge.py
+++ b/HyPER/models/hyperedge.py
@@ -3,7 +3,8 @@ import math
 
 from torch.nn import Module, Sequential as Seq, Linear, ReLU, Dropout, Sigmoid, Parameter, init
 from torch.nn.functional import relu
-from torch_geometric.utils import softmax
+
+from HyPER.utils import softmax
 
 
 class HyperedgeModel(Module):
@@ -60,7 +61,7 @@ class HyperedgeModel(Module):
         return x_hyper.sum(2)
 
     def weighting(self, x_hyper, batch_hyper):
-        coefficient = softmax(x_hyper, index=batch_hyper)
+        coefficient = softmax(x_hyper, index=batch_hyper, dim_size=x_hyper.size(1))
         return coefficient * relu(torch.mm(x_hyper, self.weight), inplace=True)
 
     def forward(self, x, u, batch, hyperedge_index, batch_hyper, r):

--- a/HyPER/utils/__init__.py
+++ b/HyPER/utils/__init__.py
@@ -1,5 +1,7 @@
+from .softmax import softmax
 from .connectivity import getUndirectedEdges
 
 __all__ = [
+    'softmax',
     'getUndirectedEdges'
 ]

--- a/HyPER/utils/softmax.py
+++ b/HyPER/utils/softmax.py
@@ -1,0 +1,32 @@
+from torch import Tensor
+from torch_geometric.utils import scatter
+
+
+def softmax(
+    src: Tensor,
+    index: Tensor,
+    dim_size: int,
+    dim: int = 0,
+) -> Tensor:
+    r"""This function is a modified version of `torch_geometric.utils.softmax`,
+    which solves value unconstrain error raised by `torch.onnx.dynamo_export`.
+
+    Args:
+        src (Tensor): The source tensor.
+        index (LongTensor): The indices of elements for applying the
+            softmax.
+        dim_size (int): Automatically create output tensor with size
+            :attr:`dim_size` in the first dimension. If set to :attr:`None`, a
+            minimal sized output tensor is returned.
+        dim (int, optional): The dimension in which to normalize.
+            (default: :obj:`0`)
+
+    :rtype: :class:`Tensor`
+    """
+    src_max = scatter(src.detach(), index, dim, dim_size=dim_size, reduce='max')
+    out = src - src_max.index_select(dim, index)
+    out = out.exp()
+    out_sum = scatter(out, index, dim, dim_size=dim_size, reduce='sum') + 1e-16
+    out_sum = out_sum.index_select(dim, index)
+
+    return out / out_sum


### PR DESCRIPTION
Use a custom `softmax` function, modified from `torch_geometric.utils.softmax`. This is a temporary fix to solve unconstrained value error raised by `torch.onnx.dynamo_export`.