### PR TITLE
Save results in `HDF5` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## \[1.1.0\] - 2024-MM-DD
 
 ### Added
+ - Add option to save results to a `HDF5` file when `.h5` extension is used in `predict_output` ([#41](https://github.com/tzuhanchang/HyPER/pull/41))
 
 ### Changed
 

--- a/HyPER/predict.py
+++ b/HyPER/predict.py
@@ -12,7 +12,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from HyPER.data import HyPERDataModule
 from HyPER.models import HyPERModel
-from HyPER.utils import getUndirectedEdges
+from HyPER.utils import getUndirectedEdges, ResultWriter
 from HyPER.topology import ttbar_allhad
 
 
@@ -99,10 +99,17 @@ def Predict(cfg : DictConfig) -> None:
     results = eval(cfg['topology'])(results)
     
     if cfg['predict_output'] is None:
-        warnings.warn("No output path is provided in `predict_output`, use default: `output.pkl`.")
-        results.to_pickle("output.pkl")
+        warnings.warn("No output path is provided in `predict_output`, use default: `output.h5`.")
+        ResultWriter(results, "output.h5")
     else:
-        results.to_pickle(str(cfg['predict_output']))
+        if str(cfg['predict_output'])[-3:] == '.h5':
+            warnings.warn("Saving results to a `.h5` file, RAW outputs will not be saved. If you want to save all output, use `.pkl` extension.", UserWarning)
+            ResultWriter(results, str(cfg['predict_output']))
+        elif str(cfg['predict_output'])[-4:] == '.pkl':
+            warnings.warn("Pickling all results (including RAW network outputs), your performance may suffer.", UserWarning)
+            results.to_pickle(str(cfg['predict_output']))
+        else:
+            raise ValueError("You must provide a file extension: `.h5` or `.pkl`.")
 
 if __name__ == "__main__":
     torch.multiprocessing.set_start_method('spawn')

--- a/HyPER/utils/__init__.py
+++ b/HyPER/utils/__init__.py
@@ -1,5 +1,7 @@
+from ._hdf5 import ResultWriter
 from .connectivity import getUndirectedEdges
 
 __all__ = [
+    'ResultWriter',
     'getUndirectedEdges'
 ]

--- a/HyPER/utils/_hdf5.py
+++ b/HyPER/utils/_hdf5.py
@@ -1,0 +1,31 @@
+import h5py
+
+import numpy as np
+import pandas as pd
+
+
+def ResultWriter(result: pd.DataFrame, dest: str, mode: str = 'a') -> None:
+    r"""Write :obj:`pandas.DataFrame` to a HDF5 file :obj:`dest`.
+
+    Args:
+        results (pandas.DataFrame): a dataframe containing unbatched 
+            network predictions.
+        dest (str): destination HDF5 file.
+        mode (optional, str): writting mode (default: :obj:`str`='a')
+    """
+    f = h5py.File(dest, mode)
+
+    out = f.create_group('OUTPUT')
+
+    keys = [ x for x in list(result.keys()) if 'HyPER_best_' in x]  # Ignore RAW outputs
+    num_entries = len(result)
+
+    for key in keys:
+        dt = np.dtype([ (f'constituent{idx}', np.int64) for idx in range(len(result[key][0])) ])
+        data = np.full((num_entries, 1), -9, dtype=dt)
+        for i in range(num_entries):
+            data[i] = tuple(result[key][i])
+
+        out.create_dataset(key, data=data)
+
+    f.close()

--- a/test/test_config.yaml
+++ b/test/test_config.yaml
@@ -33,5 +33,5 @@ continue_from_ckpt: null
 predict_set:    "test/ttbar-allhad_test.h5"
 predict_with:   "cpu"
 predict_model:  "HyPER_logs/version_0"
-predict_output: "out.pkl"
+predict_output: "out.h5"
 topology: ttbar_allhad


### PR DESCRIPTION
Add an option to save results to a `HDF5` file when user option `predict_output` has `.h5` extension. Otherwise, the results will be pickled as normal. When `HDF5` format is used, no network RAW outputs will be saved.