### PR TITLE
Fix `RuntimeError` raised during hyperedge coefficient calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Fixed
+ - Fix `RuntimeError` raised by `HyPER.utils.softmax` during coefficient calculation ([#47](https://github.com/tzuhanchang/HyPER/pull/47))
 
 ### Removed
  - Removed legacy `.json` based ttbar configuration `examples/ttbar_allhad/ttbar_allhad.json` ([#44](https://github.com/tzuhanchang/HyPER/pull/44))

--- a/HyPER/models/hyperedge.py
+++ b/HyPER/models/hyperedge.py
@@ -61,7 +61,7 @@ class HyperedgeModel(Module):
         return x_hyper.sum(2)
 
     def weighting(self, x_hyper, batch_hyper):
-        coefficient = softmax(x_hyper, index=batch_hyper, dim_size=x_hyper.size(1))
+        coefficient = softmax(x_hyper, index=batch_hyper, dim_size=x_hyper.size(0))
         return coefficient * relu(torch.mm(x_hyper, self.weight), inplace=True)
 
     def forward(self, x, u, batch, hyperedge_index, batch_hyper, r):


### PR DESCRIPTION
Fix `RuntimeError` raised by `HyPER.utils.softmax` during coefficient calculation #46. The previous bug was introduced in #36.