### PR TITLE
Add conditional hyperedge construction

### DIFF
--- a/examples/ttbar_allhad/db.yaml
+++ b/examples/ttbar_allhad/db.yaml
@@ -15,11 +15,12 @@ INPUTS:
 
 
 LABELS:
-  # These integers are `VertexID` defined in the dataset
   Edges:
-    w1: [2,3]
+    w1: [2,3] # These integers are `VertexID` defined in the dataset
     w2: [5,6]
 
   Hyperedges:
     t1: [1,2,3]
     t2: [4,5,6]
+
+  Restriction: none  # These integers are `id` defined in the dataset

--- a/test/test_db.yaml
+++ b/test/test_db.yaml
@@ -15,11 +15,12 @@ INPUTS:
 
 
 LABELS:
-  # These integers are `VertexID` defined in the dataset
   Edges:
-    w1: [2,3]
+    w1: [2,3] # These integers are `VertexID` defined in the dataset
     w2: [5,6]
 
   Hyperedges:
     t1: [1,2,3]
     t2: [4,5,6]
+
+  Restriction: none  # These integers are `id` defined in the dataset


### PR DESCRIPTION
Add conditional hyperedge construction #48. Adding the option `Restriction` in the dataset configuration file (`db.yaml`). `Restriction` takes the following values:
 - `none` (No restrictions applied)
 - `list`, for example `[[0,-1,1], [0,-2,1], [1,1,1]]`, these integers are `id` defined in the `Features`.

Only hyperedges that satisfy one of the conditions will be used for the subsequent computing.


If `id` `-1` represents electron, `-2` represents muon, `0` represents MET, and `1` represents jet, then restriction `[[0,-1,1], [0,-2,1], [1,1,1]]` will prohibit non-physical cases such as a hyperedge containing two jets and one lepton.