### PR TITLE
Use dynamic batch dimensions for `ONNX` input samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
  - Customize `softmax` function ([#36](https://github.com/tzuhanchang/HyPER/pull/36))
+ - Use dynamic dimensions for `ONNX` input samples ([#56](https://github.com/tzuhanchang/HyPER/pull/56))
 
 ### Deprecated
 


### PR DESCRIPTION
The new `ONNX` model is shown below, with dynamic dimensions `s0` (number of nodes), `s1` (number of edges), `s3` (number of global features) and `s5` (number of hyperedges).

![HyPER onnx](https://github.com/user-attachments/assets/7d5c5633-a44c-4377-a291-e254070c5c8b)

Close #55 after merging.